### PR TITLE
Use https for twitter intent

### DIFF
--- a/dialogs/tweetabletext.js
+++ b/dialogs/tweetabletext.js
@@ -35,7 +35,7 @@ CKEDITOR.dialog.add('tweetabletextDialog', function(editor) {
 
             },
             commit: function(element) {
-              var twitterBaseUrl = 'http://twitter.com/intent/tweet?';
+              var twitterBaseUrl = 'https://twitter.com/intent/tweet?';
               var encodedValue = encodeURI(this.getValue());
               twitterBaseUrl += 'text=' + encodedValue;
               element.setAttribute('href', twitterBaseUrl);
@@ -74,7 +74,7 @@ CKEDITOR.dialog.add('tweetabletextDialog', function(editor) {
       var getTweetableText = dialog.getValueOf('tab-basic', 'tweetabletext');
       var getTweetableText = encodeURI(getTweetableText);
 
-      var twitterBaseUrl = 'http://twitter.com/intent/tweet?';
+      var twitterBaseUrl = 'https://twitter.com/intent/tweet?';
       var tweetabletext = editor.document.createElement('a');
       tweetabletext.setAttribute('class', 'tweetabletext');
 


### PR DESCRIPTION
Twitter redirects to https in any case, so using an https link is faster and more secure.